### PR TITLE
Add support log analysis and interaction handling improvements

### DIFF
--- a/Commands/Trigger.cs
+++ b/Commands/Trigger.cs
@@ -139,7 +139,7 @@ internal class TriggerCommands: Command
 		}
 		await context.RespondAsync(sb.ToString());
 	}
-    internal override async Task OnModalSubmitted(DiscordSocketClient client, SocketModal context) // This is called when a modal is submitted, and the modal's CustomId was found in our command's ModalIDs.
+	internal override async Task OnModalSubmitted(DiscordSocketClient client, SocketModal context) // This is called when a modal is submitted, and the modal's CustomId was found in our command's ModalIDs.
 	{
 		var customId = context.Data.CustomId;
 		switch (customId)
@@ -178,19 +178,19 @@ internal class TriggerCommands: Command
 				var aliases = modal.Data.Components.FirstOrDefault(c => c.CustomId == "alias")?.Value;
 				if (string.IsNullOrEmpty(id)) // ...check if the ID is empty...
 				{
-					await modal.RespondAsync(EmptyId, ephemeral: true);
+					await modal.FollowupAsync(EmptyId, ephemeral: true);
 					return;
 				}
 				if (string.IsNullOrEmpty(response)) // ...check if the response text is empty...
 				{
-					await modal.RespondAsync(EmptyResponse, ephemeral: true);
+					await modal.FollowupAsync(EmptyResponse, ephemeral: true);
 					return;
 				}
 				
 				id = id.ToLower(); // ...make it lowercase to avoid case sensitivity issues...
 				if (Program.TriggerItems.Any(t => t.Id == id)) // ...check if the trigger already exists...
 				{
-					await modal.RespondAsync(string.Format(AlreadyExists, id), ephemeral: true);
+					await modal.FollowupAsync(string.Format(AlreadyExists, id), ephemeral: true);
 					return;
 				}
 
@@ -216,7 +216,7 @@ internal class TriggerCommands: Command
 					Aliases = aliasesList,
 					Response = response
 				}); // ...add the trigger to the list...
-				await modal.RespondAsync($"Added trigger with ID `{id}`, and response:\n```\n{response}\n```", ephemeral: true); // ...and respond with the trigger and content.
+				await modal.FollowupAsync($"Added trigger with ID `{id}`, and response:\n```\n{response}\n```", ephemeral: true); // ...and respond with the trigger and content.
 				break;
 		}
 	}
@@ -365,16 +365,16 @@ internal class TriggerCommands: Command
 		await context.RespondAsync(options);
 	}
 
-	private async Task DoTriggerUpdate(string? id, string? response, string? aliases, IDiscordInteraction context)
+	private async Task DoTriggerUpdate(string? id, string? response, string? aliases, SocketModal context)
 	{
 		if (string.IsNullOrEmpty(id)) // ...Check if the ID is empty...
 		{
-			await context.RespondAsync(EmptyId, ephemeral: true);
+			await context.FollowupAsync(EmptyId, ephemeral: true);
 			return;
 		}
 		if (string.IsNullOrEmpty(response)) // ...check if the response text is empty...
 		{
-			await context.RespondAsync(EmptyResponse, ephemeral: true);
+			await context.FollowupAsync(EmptyResponse, ephemeral: true);
 			return;
 		}
 		
@@ -382,7 +382,7 @@ internal class TriggerCommands: Command
 		var existing = Program.TriggerItems.FirstOrDefault(t => t.Id == id);
 		if (existing == null) // ...check if the trigger exists...
 		{
-			await context.RespondAsync(string.Format(NotFound, id), ephemeral: true);
+			await context.FollowupAsync(string.Format(NotFound, id), ephemeral: true);
 			return;
 		}
 		
@@ -412,7 +412,7 @@ internal class TriggerCommands: Command
 			TimesTriggered = v
 		}); // ...add the new trigger to the list...
 		
-		await context.RespondAsync($"Updated trigger with ID `{id}`, and response:\n```\n{response}\n```", ephemeral: true); // ...and respond with the new trigger and content.
+		await context.FollowupAsync($"Updated trigger with ID `{id}`, and response:\n```\n{response}\n```", ephemeral: true); // ...and respond with the new trigger and content.
 	}
 	private List<string> CheckForConflicts(List<string> toBeAddedAliases)
 	{

--- a/Events.cs
+++ b/Events.cs
@@ -35,30 +35,48 @@ internal static class Events
 
 	internal static async Task SelectMenuHandler(SocketMessageComponent c)
 	{
-		if (c.User is not SocketGuildUser u) await c.RespondAsync("Couldn't find user");
-		else
+		if (c.User is not SocketGuildUser u)
 		{
-			var chosenRoles = RolePicker.roles.Where(r => c.Data.Values.Contains(r.Id.ToString())).ToList();
-			var removedRoles = RolePicker.roles.Where(r => !c.Data.Values.Contains(r.Id.ToString())).ToList();
-			
-			var chosenRolesJoined = string.Join(", ", chosenRoles.ConvertAll(x => $"<@&{x.Id}>"));
-			var removedRolesJoined = string.Join(", ", removedRoles.ConvertAll(x => $"<@&{x.Id}>"));
+			await c.RespondAsync("Couldn't find user");
+			return;
+		}
 
-			var sb = new StringBuilder();
+		var chosenRoles = RolePicker.roles.Where(r => c.Data.Values.Contains(r.Id.ToString())).ToList();
+		var removedRoles = RolePicker.roles.Where(r => !c.Data.Values.Contains(r.Id.ToString())).ToList();
+		
+		var chosenRolesJoined = string.Join(", ", chosenRoles.ConvertAll(x => $"<@&{x.Id}>"));
+		var removedRolesJoined = string.Join(", ", removedRoles.ConvertAll(x => $"<@&{x.Id}>"));
 
-			sb.Append((chosenRoles.Count == 0
-				? "Didn't give any roles"
-				: $"Gave {u.Username} the roles {chosenRolesJoined}") + " "); // "[text] "
+		var sb = new StringBuilder();
 
-			sb.Append(removedRoles.Count == 0
-				? ""
-				: $"and removed the roles {removedRolesJoined}");
-			
+		sb.Append((chosenRoles.Count == 0
+			? "Didn't give any roles"
+			: $"Gave {u.Username} the roles {chosenRolesJoined}") + " ");
+
+		sb.Append(removedRoles.Count == 0
+			? ""
+			: $"and removed the roles {removedRolesJoined}");
+
+		await c.DeferAsync(ephemeral: true);
+
+		Program.RunBackgroundTask(nameof(SelectMenuHandler), async () =>
+		{
 			await u.RemoveRolesAsync(removedRoles);
 			await u.AddRolesAsync(chosenRoles);
-			
-			await c.RespondAsync(sb.ToString(), ephemeral: true, allowedMentions:AllowedMentions.None);
+
+			await c.FollowupAsync(sb.ToString(), ephemeral: true, allowedMentions: AllowedMentions.None);
+		});
+	}
+
+	internal static async Task ButtonHandler(SocketMessageComponent component)
+	{
+		if (component.Data.CustomId.StartsWith(SupportLogAnalyzer.PaginationCustomIdPrefix, StringComparison.Ordinal))
+		{
+			await Program.SupportLogAnalyzer.TryHandlePaginationAsync(component);
+			return;
 		}
+
+		await component.RespondAsync("That button is not handled.", ephemeral: true);
 	}
 
 	internal static async Task MessageUpdated(Cacheable<IMessage, ulong> orig, SocketMessage updated, ISocketMessageChannel channel)
@@ -95,7 +113,7 @@ internal static class Events
                 Program.WatchList.Remove(checkedMessage.Id);
             }
         }
-		if (msg is not SocketUserMessage || msg.Author is { IsBot: true } or { IsWebhook: true })
+		if (msg is not SocketUserMessage userMessage || msg.Author is { IsBot: true } or { IsWebhook: true })
 		{
 			return;
 		}
@@ -119,6 +137,11 @@ internal static class Events
 				
 				await channel.CreateThreadAsync($"{msg.Author.Username}'s mod showoff thread.", message: msg);
 			}
+		}
+
+		if (await Program.SupportLogAnalyzer.TryHandleMessageAsync(userMessage))
+		{
+			return;
 		}
 		
 		if (user.Roles.Any(role => Program.IgnoredRoleIds.ToList().Contains(role.Id)))
@@ -174,7 +197,8 @@ internal static class Events
 		
 		foreach (var cmd in Program.CommandsList.Where(cmd => cmd.ModalIDs.Contains(modal.Data.CustomId)))
 		{
-			await cmd.OnModalSubmitted(Program.Client, modal);
+			await modal.DeferAsync(ephemeral: true);
+			Program.RunBackgroundTask(nameof(ModalSubmit), () => cmd.OnModalSubmitted(Program.Client, modal));
 			return;
 		}
 		

--- a/NelsonsWeirdTwin.csproj
+++ b/NelsonsWeirdTwin.csproj
@@ -5,7 +5,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	  <Configurations>ProdBot;TestBot</Configurations>
+	<Configurations>ProdBot;TestBot</Configurations>
+	<UseLocalErrorAnalyzerCore Condition="'$(UseLocalErrorAnalyzerCore)' == ''">false</UseLocalErrorAnalyzerCore>
+	<ErrorAnalyzerCoreVersion Condition="'$(ErrorAnalyzerCoreVersion)' == ''">*</ErrorAnalyzerCoreVersion>
+	<ErrorAnalyzerCoreProjectPath Condition="'$(ErrorAnalyzerCoreProjectPath)' == ''">..\ErrorAnalyzer\src\ErrorAnalyzer.Core\ErrorAnalyzer.Core.csproj</ErrorAnalyzerCoreProjectPath>
   </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)' == 'ProdBot'">
 		<DefineConstants>PROD</DefineConstants>
@@ -18,6 +21,14 @@
     <PackageReference Include="Discord.Net" Version="3.18.0-beta.2" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="OllamaSharp" Version="5.1.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalErrorAnalyzerCore)' == 'true'">
+    <ProjectReference Include="$(ErrorAnalyzerCoreProjectPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalErrorAnalyzerCore)' != 'true'">
+    <PackageReference Include="ScheduleOne.ErrorAnalyzer.Core" Version="$(ErrorAnalyzerCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -29,6 +29,9 @@ internal static class Program
     public static List<TriggerItem> TriggerItems = [];
 	internal static readonly List<Command> CommandsList = [];
 	internal static readonly List<ulong> WatchList = [];
+	internal static readonly HashSet<ulong> SupportChannelIds = [];
+	internal static readonly SupportLogAnalyzer SupportLogAnalyzer = new();
+	private const ulong DefaultProductionSupportChannelId = 1354832385128271922;
 
 	// sorry repo, im not sure how to set this up for multiple testers
 	// you'll probably figure it out.
@@ -63,6 +66,7 @@ internal static class Program
 	{
 		Directory.SetCurrentDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 		Env.Load("token.env");
+		LoadSupportChannelIds();
 		await TryLoadTriggers();
 #if PROD
 		token = Environment.GetEnvironmentVariable("TOKEN");
@@ -80,29 +84,133 @@ internal static class Program
 
 		var config = new DiscordSocketConfig
 		{
-			GatewayIntents = GatewayIntents.All
+			GatewayIntents = GatewayIntents.All,
+			ResponseInternalTimeCheck = false,
+			UseInteractionSnowflakeDate = false
 		};
 		Client = new DiscordSocketClient(config);
 
 		Client.Log += message =>
 		{
-			Console.WriteLine(message.Message);
+			var exceptionText = message.Exception is null ? string.Empty : $"\n{message.Exception}";
+			Console.WriteLine($"[{message.Severity}] {message.Source}: {message.Message}{exceptionText}");
 			return Task.CompletedTask;
 		};
-		Client.Ready += Events.OnReady;
+		Client.Connected += () =>
+		{
+			Console.WriteLine("Discord gateway connected.");
+			return Task.CompletedTask;
+		};
+		Client.Disconnected += exception =>
+		{
+			Console.WriteLine(exception is null
+				? "Discord gateway disconnected without an exception."
+				: $"Discord gateway disconnected: {exception}");
+			return Task.CompletedTask;
+		};
+		Client.Ready += () => RunGatewayHandler(nameof(Events.OnReady), Events.OnReady);
 		
-		Client.MessageReceived += Events.MessageReceived;
-		Client.UserBanned += Events.OnUserBanned;
+		Client.MessageReceived += message => RunGatewayHandler(nameof(Events.MessageReceived), () => Events.MessageReceived(message));
+		Client.UserBanned += (user, guild) => RunGatewayHandler(nameof(Events.OnUserBanned), () => Events.OnUserBanned(user, guild));
 
-		Client.SlashCommandExecuted += Events.SlashCommandSubmit;
-		Client.ModalSubmitted += Events.ModalSubmit;
-		Client.SelectMenuExecuted += Events.SelectMenuHandler;
-		Client.AutocompleteExecuted += Events.AutoCompleteHandler;
+		Client.SlashCommandExecuted += command =>
+		{
+			return RunInteractionHandler(nameof(Events.SlashCommandSubmit), () => Events.SlashCommandSubmit(command));
+		};
+		Client.ModalSubmitted += modal =>
+		{
+			return RunInteractionHandler(nameof(Events.ModalSubmit), () => Events.ModalSubmit(modal));
+		};
+		Client.ButtonExecuted += component =>
+		{
+			return RunInteractionHandler(nameof(Events.ButtonHandler), () => Events.ButtonHandler(component));
+		};
+		Client.SelectMenuExecuted += component =>
+		{
+			return RunInteractionHandler(nameof(Events.SelectMenuHandler), () => Events.SelectMenuHandler(component));
+		};
+		Client.AutocompleteExecuted += context =>
+		{
+			return RunInteractionHandler(nameof(Events.AutoCompleteHandler), () => Events.AutoCompleteHandler(context));
+		};
 		
 		await Client.LoginAsync(TokenType.Bot, token);
 		await Client.StartAsync();
 
 		await Task.Delay(-1);
+	}
+
+	private static Task RunGatewayHandler(string handlerName, Func<Task> handler)
+	{
+		RunBackgroundTask(handlerName, handler);
+
+		return Task.CompletedTask;
+	}
+
+	private static Task RunInteractionHandler(string handlerName, Func<Task> handler)
+	{
+		return HandleInteractionAsync(handlerName, handler);
+	}
+
+	private static async Task HandleInteractionAsync(string handlerName, Func<Task> handler)
+	{
+		try
+		{
+			await handler();
+		}
+		catch (TimeoutException ex)
+		{
+			Console.WriteLine($"Unhandled interaction timeout in {handlerName}: {ex.Message}");
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"Unhandled exception in {handlerName}: {ex}");
+		}
+	}
+
+	internal static void RunBackgroundTask(string operationName, Func<Task> operation)
+	{
+		_ = Task.Run(async () =>
+		{
+			try
+			{
+				await operation();
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"Unhandled exception in {operationName}: {ex}");
+			}
+		});
+	}
+
+	private static void LoadSupportChannelIds()
+	{
+		SupportChannelIds.Clear();
+
+		var rawValue = Environment.GetEnvironmentVariable("SUPPORT_CHANNEL_IDS");
+		if (string.IsNullOrWhiteSpace(rawValue))
+		{
+			SupportChannelIds.Add(DefaultProductionSupportChannelId);
+			Console.WriteLine($"Support log analysis enabled for the default production support channel ({DefaultProductionSupportChannelId}). Set SUPPORT_CHANNEL_IDS to override it.");
+			return;
+		}
+
+		foreach (var token in rawValue.Split([',', ';', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (!ulong.TryParse(token, out var channelId))
+			{
+				Console.WriteLine($"Ignoring invalid support channel ID '{token}'.");
+				continue;
+			}
+
+			SupportChannelIds.Add(channelId);
+		}
+
+		Console.WriteLine(
+			SupportChannelIds.Count == 0
+				? "Support log analysis is disabled. SUPPORT_CHANNEL_IDS did not contain any valid IDs."
+				: $"Support log analysis enabled for {SupportChannelIds.Count} {Utils.Plural(SupportChannelIds.Count, "channel")}."
+		);
 	}
 	
 	#region Triggers and Command Loading
@@ -237,6 +345,13 @@ internal static class Program
 			var guild = Client.GetGuild(1349221936470687764); // S1 Modding
 			guild ??= Client.GetGuild(1359858871270637762); // Bot Test Server
 			guild ??= Client.GetGuild(1368263313531732008); // Pacas test server
+			guild ??= Client.Guilds.FirstOrDefault();
+
+			if (guild == null)
+			{
+				Console.WriteLine("WARNING: No guild was available for command registration.");
+				return;
+			}
 
 			if (reregister)
 			{

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 Simple discord bot with auto responses to common phrases using modals, events, and string checking.
+
+Automatic log analysis defaults to the S1 Modding #support channel (`1354832385128271922`).
+
+Set `SUPPORT_CHANNEL_IDS` to a comma-separated list of Discord channel IDs to override that default and control where automatic log analysis replies run for `.log`, `.txt`, or pasted error logs.
+
+## ErrorAnalyzer.Core dependency
+
+- The bot uses the `ScheduleOne.ErrorAnalyzer.Core` package from NuGet.
+- The dependency switch is isolated in `NelsonsWeirdTwin.csproj`:
+  - local project mode: `UseLocalErrorAnalyzerCore=true`
+  - package mode: `UseLocalErrorAnalyzerCore=false` with `ErrorAnalyzerCoreVersion=*`
+- Use the package mode for normal builds, and switch to the local project mode when developing `ErrorAnalyzer.Core` side by side with the bot.

--- a/SupportLogAnalyzer.cs
+++ b/SupportLogAnalyzer.cs
@@ -1,0 +1,446 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using ErrorAnalyzer.Core;
+using ErrorAnalyzer.Core.Models;
+
+namespace NelsonsWeirdTwin;
+
+internal sealed class SupportLogAnalyzer
+{
+	internal const string PaginationCustomIdPrefix = "support-log-page:";
+
+	private static readonly HttpClient HttpClient = new();
+	private static readonly string[] SupportedAttachmentExtensions = [".log", ".txt"];
+	private static readonly ConcurrentDictionary<ulong, PaginationState> PaginationStates = new();
+
+	private const int MaxAttachmentBytes = 10 * 1024 * 1024;
+	private const int IssueGroupsPerPage = 3;
+	private const int MaxEmbedFieldLength = 1024;
+
+	private readonly LogAnalyzer _analyzer = new();
+
+	internal async Task<bool> TryHandleMessageAsync(SocketUserMessage message)
+	{
+		if (!Program.SupportChannelIds.Contains(message.Channel.Id))
+		{
+			return false;
+		}
+
+		try
+		{
+			var input = await TryExtractLogInputAsync(message.Attachments);
+			if (input == null)
+			{
+				return false;
+			}
+
+			if (!string.IsNullOrWhiteSpace(input.ErrorMessage))
+			{
+				await SendReplyAsync(message, BuildStatusEmbed(input.SourceName, input.ErrorMessage, Color.Orange));
+				return true;
+			}
+
+			if (!ContainsException(input.Text))
+			{
+				return false;
+			}
+
+			var pageSet = BuildPages(input);
+			if (pageSet == null)
+			{
+				return false;
+			}
+
+			var sentMessage = await message.Channel.SendMessageAsync(
+				embed: pageSet.Embeds[0],
+				components: BuildPaginationComponents(0, pageSet.Embeds.Count),
+				messageReference: new MessageReference(message.Id),
+				allowedMentions: AllowedMentions.None);
+
+			if (pageSet.Embeds.Count > 1)
+			{
+				PaginationStates[sentMessage.Id] = new PaginationState(pageSet.Embeds);
+			}
+
+			return true;
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"Support log analysis failed: {ex}");
+			await SendReplyAsync(
+				message,
+				BuildStatusEmbed("discord-log", "I hit an error while analyzing that log. Please try again or let a helper review it manually.", Color.Orange));
+			return true;
+		}
+	}
+
+	internal async Task<bool> TryHandlePaginationAsync(SocketMessageComponent component)
+	{
+		if (!component.Data.CustomId.StartsWith(PaginationCustomIdPrefix, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		try
+		{
+			await component.DeferAsync();
+		}
+		catch (Exception ex)
+		{
+			var interactionAgeMs = (DateTimeOffset.UtcNow - component.CreatedAt).TotalMilliseconds;
+			Console.WriteLine($"[SupportLogAnalyzer] Failed to defer pagination interaction for message {component.Message?.Id}: {ex.Message} (interaction age: {interactionAgeMs:F0}ms)");
+			return true;
+		}
+
+		if (!PaginationStates.TryGetValue(component.Message.Id, out var state))
+		{
+			try
+			{
+				await component.ModifyOriginalResponseAsync(message =>
+				{
+					message.Content = "That log analysis is no longer interactive.";
+					message.Embeds = null;
+					message.Components = null;
+				});
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"Failed to remove stale pagination state for message {component.Message?.Id}: {ex.Message}");
+			}
+
+			return true;
+		}
+
+		var action = component.Data.CustomId[PaginationCustomIdPrefix.Length..];
+		lock (state.SyncRoot)
+		{
+			if (action == "prev" && state.CurrentPage > 0)
+			{
+				state.CurrentPage -= 1;
+			}
+			else if (action == "next" && state.CurrentPage < state.Embeds.Count - 1)
+			{
+				state.CurrentPage += 1;
+			}
+		}
+
+		try
+		{
+			await component.ModifyOriginalResponseAsync(properties =>
+			{
+				properties.Embed = state.Embeds[state.CurrentPage];
+				properties.Components = BuildPaginationComponents(state.CurrentPage, state.Embeds.Count);
+			});
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[SupportLogAnalyzer] Failed interactive pagination update for message {component.Message?.Id}: {ex.Message}");
+		}
+
+		return true;
+	}
+
+	private async Task<LogInput> TryExtractLogInputAsync(IReadOnlyCollection<Attachment> attachments)
+	{
+		foreach (var attachment in attachments)
+		{
+			if (!HasSupportedExtension(attachment.Filename))
+			{
+				continue;
+			}
+
+			if (attachment.Size > MaxAttachmentBytes)
+			{
+				return new LogInput(
+					attachment.Filename,
+					string.Empty,
+					$"`{attachment.Filename}` is too large to analyze automatically. Please keep it under {MaxAttachmentBytes / 1024 / 1024} MB.");
+			}
+
+			var text = await HttpClient.GetStringAsync(attachment.Url);
+			return new LogInput(attachment.Filename, text);
+		}
+
+		return null;
+	}
+
+	private PageSet BuildPages(LogInput input)
+	{
+		var result = _analyzer.AnalyzeTextAsDto(input.Text);
+		var findings = SelectOneFindingPerMod(result.Diagnoses);
+		if (findings.Count == 0)
+		{
+			return null;
+		}
+
+		var adviceGroups = BuildAdviceGroupPageItems(result);
+		if (adviceGroups.Count == 0)
+		{
+			return null;
+		}
+
+		var embeds = new List<Embed>();
+		var pageCount = (int)Math.Ceiling(adviceGroups.Count / (double)IssueGroupsPerPage);
+
+		for (var pageIndex = 0; pageIndex < pageCount; pageIndex++)
+		{
+			var pageItems = adviceGroups
+				.Skip(pageIndex * IssueGroupsPerPage)
+				.Take(IssueGroupsPerPage)
+				.ToArray();
+
+			var embedBuilder = new EmbedBuilder()
+				.WithTitle($"Log analysis for {input.SourceName}")
+				.WithColor(GetColor(pageItems.SelectMany(pageItem => pageItem.Diagnoses)));
+
+			foreach (var pageItem in pageItems)
+			{
+				embedBuilder.AddField(
+					EscapeMarkdown(pageItem.Group.Title),
+					BuildAdviceGroupFieldValue(pageItem.Group),
+					false);
+			}
+
+			var embed = embedBuilder
+				.AddField("Runtime", result.Runtime, true)
+				.AddField("Issue Groups", adviceGroups.Count.ToString(), true)
+				.AddField("Affected Mods", findings.Count.ToString(), true)
+				.WithFooter($"Showing issues {pageIndex * IssueGroupsPerPage + 1}-{pageIndex * IssueGroupsPerPage + pageItems.Length} of {adviceGroups.Count} - Page {pageIndex + 1}/{pageCount}")
+				.Build();
+
+			embeds.Add(embed);
+		}
+
+		return new PageSet(embeds);
+	}
+
+	private static List<AdviceGroupPageItem> BuildAdviceGroupPageItems(LogAnalysisResultDto result)
+	{
+		var diagnosesByGroupKey = result.Diagnoses
+			.GroupBy(diagnosis => diagnosis.Advice.GroupKey, StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(
+				group => group.Key,
+				group => (IReadOnlyList<DiagnosisDto>)group.ToList(),
+				StringComparer.OrdinalIgnoreCase);
+
+		var adviceGroups = result.AdviceGroups is { Count: > 0 }
+			? result.AdviceGroups
+			: BuildAdviceGroupsFromDiagnoses(result.Diagnoses);
+
+		return adviceGroups
+			.Select(group => new AdviceGroupPageItem(
+				group,
+				diagnosesByGroupKey.TryGetValue(group.GroupKey, out var diagnoses)
+					? diagnoses
+					: Array.Empty<DiagnosisDto>()))
+			.ToList();
+	}
+
+	private static IReadOnlyList<DiagnosisAdviceGroupDto> BuildAdviceGroupsFromDiagnoses(IReadOnlyList<DiagnosisDto> diagnoses)
+	{
+		return diagnoses
+			.GroupBy(diagnosis => diagnosis.Advice.GroupKey, StringComparer.OrdinalIgnoreCase)
+			.Select(group =>
+			{
+				var primaryDiagnosis = group
+					.OrderBy(diagnosis => diagnosis.Advice.Priority)
+					.ThenBy(diagnosis => diagnosis.LineNumber)
+					.First();
+				var affectedMods = group
+					.Select(diagnosis => string.IsNullOrWhiteSpace(diagnosis.ModName) ? "Unknown mod" : diagnosis.ModName.Trim())
+					.Distinct(StringComparer.OrdinalIgnoreCase)
+					.OrderBy(modName => modName, StringComparer.OrdinalIgnoreCase)
+					.ToArray();
+
+				return new DiagnosisAdviceGroupDto(
+					primaryDiagnosis.Advice.GroupKey,
+					primaryDiagnosis.Advice.Priority,
+					primaryDiagnosis.Advice.Urgency,
+					primaryDiagnosis.Advice.Title,
+					primaryDiagnosis.Advice.PrimaryAction,
+					primaryDiagnosis.Advice.Explanation,
+					affectedMods,
+					group.Count(),
+					group.Sum(diagnosis => diagnosis.OccurrenceCount));
+			})
+			.OrderBy(group => group.Priority)
+			.ThenBy(group => group.Title, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+	}
+
+	private static string BuildAdviceGroupFieldValue(DiagnosisAdviceGroupDto group)
+	{
+		var action = !string.IsNullOrWhiteSpace(group.PrimaryAction)
+			? group.PrimaryAction
+			: !string.IsNullOrWhiteSpace(group.Explanation)
+				? group.Explanation
+				: "Review the affected mods and their install state.";
+		var modLabel = group.AffectedMods.Count == 1
+			? "Affected mod"
+			: $"Affected mods ({group.AffectedMods.Count})";
+		var prefix = $"{action}\n\n{modLabel}: ";
+		var availableLength = Math.Max(32, MaxEmbedFieldLength - prefix.Length);
+
+		return prefix + BuildModList(group.AffectedMods, availableLength);
+	}
+
+	private static string BuildModList(IReadOnlyList<string> modNames, int maxLength)
+	{
+		if (modNames.Count == 0)
+		{
+			return "Unknown mod";
+		}
+
+		var builder = new StringBuilder();
+		for (var index = 0; index < modNames.Count; index++)
+		{
+			var escapedModName = EscapeMarkdown(modNames[index]);
+			var segment = builder.Length == 0 ? escapedModName : $", {escapedModName}";
+			if (builder.Length + segment.Length <= maxLength)
+			{
+				builder.Append(segment);
+				continue;
+			}
+
+			var remainingCount = modNames.Count - index;
+			var suffix = builder.Length == 0
+				? $"+{remainingCount} mod{(remainingCount == 1 ? string.Empty : "s")}"
+				: $", +{remainingCount} more";
+
+			if (builder.Length + suffix.Length <= maxLength)
+			{
+				builder.Append(suffix);
+			}
+
+			break;
+		}
+
+		return builder.Length == 0 ? "Unknown mod" : builder.ToString();
+	}
+
+	private static List<DiagnosisDto> SelectOneFindingPerMod(IReadOnlyList<DiagnosisDto> diagnoses)
+	{
+		return diagnoses
+			.GroupBy(diagnosis => string.IsNullOrWhiteSpace(diagnosis.ModName) ? "Unknown mod" : diagnosis.ModName, StringComparer.OrdinalIgnoreCase)
+			.Select(group => group
+				.OrderBy(diagnosis => diagnosis.Advice.Priority)
+				.ThenByDescending(diagnosis => GetSeverityRank(diagnosis.Severity))
+				.ThenByDescending(diagnosis => GetConfidenceRank(diagnosis.Confidence))
+				.ThenByDescending(diagnosis => diagnosis.OccurrenceCount)
+				.First())
+			.OrderBy(diagnosis => diagnosis.Advice.Priority)
+			.ThenByDescending(diagnosis => GetSeverityRank(diagnosis.Severity))
+			.ThenBy(diagnosis => diagnosis.ModName ?? "Unknown mod", StringComparer.OrdinalIgnoreCase)
+			.ToList();
+	}
+
+	private static MessageComponent BuildPaginationComponents(int currentPage, int pageCount)
+	{
+		if (pageCount <= 1)
+		{
+			return null;
+		}
+
+		return new ComponentBuilder()
+			.WithButton("Previous", PaginationCustomIdPrefix + "prev", ButtonStyle.Secondary, disabled: currentPage == 0)
+			.WithButton("Next", PaginationCustomIdPrefix + "next", ButtonStyle.Secondary, disabled: currentPage >= pageCount - 1)
+			.Build();
+	}
+
+	private static async Task SendReplyAsync(SocketUserMessage message, Embed embed)
+	{
+		await message.Channel.SendMessageAsync(
+			embed: embed,
+			messageReference: new MessageReference(message.Id),
+			allowedMentions: AllowedMentions.None);
+	}
+
+	private static Embed BuildStatusEmbed(string sourceName, string message, Color color)
+	{
+		return new EmbedBuilder()
+			.WithTitle($"Log analysis for {sourceName}")
+			.WithColor(color)
+			.WithDescription(message)
+			.WithFooter($"Powered by ErrorAnalyzer.Core {ErrorAnalyzerBuildInfo.Version}")
+			.Build();
+	}
+
+	private static bool HasSupportedExtension(string filename)
+	{
+		return SupportedAttachmentExtensions.Any(extension => filename.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static bool ContainsException(string text)
+	{
+		return text.Contains("Exception", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static int GetSeverityRank(string severity)
+	{
+		return severity switch
+		{
+			"Error" => 3,
+			"Warning" => 2,
+			_ => 1,
+		};
+	}
+
+	private static int GetConfidenceRank(string confidence)
+	{
+		return confidence switch
+		{
+			"High" => 3,
+			"Medium" => 2,
+			_ => 1,
+		};
+	}
+
+	private static Color GetColor(IEnumerable<DiagnosisDto> diagnoses)
+	{
+		if (diagnoses.Any(diagnosis => string.Equals(diagnosis.Severity, "Error", StringComparison.OrdinalIgnoreCase)))
+		{
+			return Color.Red;
+		}
+
+		if (diagnoses.Any(diagnosis => string.Equals(diagnosis.Severity, "Warning", StringComparison.OrdinalIgnoreCase)))
+		{
+			return Color.Orange;
+		}
+
+		return Color.Blue;
+	}
+
+	private static string EscapeMarkdown(string value)
+	{
+		return value
+			.Replace("\\", "\\\\", StringComparison.Ordinal)
+			.Replace("`", "\\`", StringComparison.Ordinal)
+			.Replace("*", "\\*", StringComparison.Ordinal)
+			.Replace("_", "\\_", StringComparison.Ordinal);
+	}
+
+	private sealed record LogInput(string SourceName, string Text, string ErrorMessage = null);
+
+	private sealed record AdviceGroupPageItem(DiagnosisAdviceGroupDto Group, IReadOnlyList<DiagnosisDto> Diagnoses);
+
+	private sealed class PaginationState
+	{
+		internal PaginationState(IReadOnlyList<Embed> embeds)
+		{
+			Embeds = embeds;
+		}
+
+		internal object SyncRoot { get; } = new();
+		internal IReadOnlyList<Embed> Embeds { get; }
+		internal int CurrentPage { get; set; }
+	}
+
+	private sealed record PageSet(IReadOnlyList<Embed> Embeds);
+}


### PR DESCRIPTION
Add automated support log analysis to the bot and improve how Discord events and interactions are handled.

This change introduces a new `SupportLogAnalyzer` class for the support channel, with attachment-based log analysis, embed responses, and button-driven pagination for multi-page results. Support log analysis defaults to the S1 modding support channel ID `1354832385128271922`, while `SUPPORT_CHANNEL_IDS` environment variable can be set to override the channel list when needed.

It also hardens the bot’s Discord event pipeline by routing gateway and interaction handlers through centralized async wrappers with exception logging, adding connection/disconnection logging, and updating modal submission flows to defer first and respond with follow-up messages where required. This was needed to fix some issues with the pagination interactions.

The log analyzer is powered by `ScheduleOne.ErrorAnalyzer.Core`, with the project configured to resolve it either from the NuGet package or from a local project reference through MSBuild properties. The README was updated to document the default support-channel behavior and the analyzer dependency setup.