### PR TITLE
Add slash command for support log analysis w/ settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 # Other
 triggers.json
 warns.json
+support-log-settings.json
+testing.txt

--- a/Commands/AnalyzeCommand.cs
+++ b/Commands/AnalyzeCommand.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+
+namespace NelsonsWeirdTwin.Commands;
+
+internal sealed class AnalyzeCommand : Command
+{
+	internal override SlashCommandProperties CommandProperties =>
+		new SlashCommandBuilder()
+			.WithName("analyze")
+			.WithDescription("Analyze a support log or manage analysis settings.")
+			.AddOption(
+				new SlashCommandOptionBuilder()
+					.WithName("message")
+					.WithDescription("Analyze a message with a .log or .txt attachment.")
+					.WithType(ApplicationCommandOptionType.SubCommand)
+					.AddOption(
+						new SlashCommandOptionBuilder()
+							.WithName("target")
+							.WithDescription("A message ID in this channel or a full Discord message link.")
+							.WithType(ApplicationCommandOptionType.String)
+							.WithRequired(true)
+					)
+			)
+			.AddOption(
+				new SlashCommandOptionBuilder()
+					.WithName("settings")
+					.WithDescription("Manage which channels allow /analyze.")
+					.WithType(ApplicationCommandOptionType.SubCommandGroup)
+					.AddOption(
+						new SlashCommandOptionBuilder()
+							.WithName("list")
+							.WithDescription("List the configured analyze channels.")
+							.WithType(ApplicationCommandOptionType.SubCommand)
+					)
+					.AddOption(
+						new SlashCommandOptionBuilder()
+							.WithName("add-channel")
+							.WithDescription("Add a channel where /analyze can be used.")
+							.WithType(ApplicationCommandOptionType.SubCommand)
+							.AddOption(
+								new SlashCommandOptionBuilder()
+									.WithName("channel")
+									.WithDescription("The support or testing channel to allow.")
+									.WithType(ApplicationCommandOptionType.Channel)
+									.WithRequired(true)
+							)
+					)
+					.AddOption(
+						new SlashCommandOptionBuilder()
+							.WithName("remove-channel")
+							.WithDescription("Remove a channel from /analyze.")
+							.WithType(ApplicationCommandOptionType.SubCommand)
+							.AddOption(
+								new SlashCommandOptionBuilder()
+									.WithName("channel")
+									.WithDescription("The support or testing channel to remove.")
+									.WithType(ApplicationCommandOptionType.Channel)
+									.WithRequired(true)
+							)
+					)
+			)
+			.Build();
+
+	internal override async Task OnExecuted(DiscordSocketClient client, SocketSlashCommand context)
+	{
+		await context.DeferAsync(ephemeral: true);
+
+		var rootOption = context.Data.Options.FirstOrDefault();
+		if (rootOption == null)
+		{
+			await SetResponseAsync(context, "Missing analyze subcommand.");
+			return;
+		}
+
+		switch (rootOption.Name)
+		{
+			case "message":
+				await HandleMessageAsync(client, context, rootOption);
+				break;
+			case "settings":
+				await HandleSettingsAsync(client, context, rootOption);
+				break;
+			default:
+				await SetResponseAsync(context, $"Unknown analyze subcommand `{rootOption.Name}`.");
+				break;
+		}
+	}
+
+	private static async Task HandleMessageAsync(DiscordSocketClient client, SocketSlashCommand context, SocketSlashCommandDataOption subcommand)
+	{
+		if (!Program.SupportChannelIds.Contains(context.Channel.Id))
+		{
+			await SetResponseAsync(context, "This command can only be used in configured analyze channels.");
+			return;
+		}
+
+		var target = subcommand.Options.FirstOrDefault(option => option.Name == "target")?.Value as string;
+		if (string.IsNullOrWhiteSpace(target))
+		{
+			await SetResponseAsync(context, "You must provide a message ID or Discord message link.");
+			return;
+		}
+
+		var resolvedTarget = await TryResolveTargetMessageAsync(client, context, target);
+		if (resolvedTarget.Message == null)
+		{
+			await SetResponseAsync(context, resolvedTarget.ErrorMessage);
+			return;
+		}
+
+		await Program.SupportLogAnalyzer.AnalyzeMessageAsync(context, resolvedTarget.Message);
+	}
+
+	private static async Task HandleSettingsAsync(DiscordSocketClient client, SocketSlashCommand context, SocketSlashCommandDataOption groupOption)
+	{
+		if (!HasManageMessagesPermission(context))
+		{
+			await SetResponseAsync(context, "You need `ManageMessages` to change analyze settings.");
+			return;
+		}
+
+		var subcommand = groupOption.Options.FirstOrDefault();
+		if (subcommand == null)
+		{
+			await SetResponseAsync(context, "Missing analyze settings subcommand.");
+			return;
+		}
+
+		switch (subcommand.Name)
+		{
+			case "list":
+				await SetResponseAsync(context, BuildChannelListMessage());
+				break;
+			case "add-channel":
+				await UpdateChannelAsync(client, context, subcommand, addChannel: true);
+				break;
+			case "remove-channel":
+				await UpdateChannelAsync(client, context, subcommand, addChannel: false);
+				break;
+			default:
+				await SetResponseAsync(context, $"Unknown analyze settings subcommand `{subcommand.Name}`.");
+				break;
+		}
+	}
+
+	private static async Task UpdateChannelAsync(DiscordSocketClient client, SocketSlashCommand context, SocketSlashCommandDataOption subcommand, bool addChannel)
+	{
+		var channelOption = subcommand.Options.FirstOrDefault(option => option.Name == "channel")?.Value as IChannel;
+		if (channelOption == null)
+		{
+			await SetResponseAsync(context, "You must pick a channel.");
+			return;
+		}
+
+		var liveChannel = await TryGetMessageChannelAsync(client, channelOption.Id);
+		if (liveChannel == null)
+		{
+			await SetResponseAsync(context, "That channel does not support messages.");
+			return;
+		}
+
+		if (addChannel)
+		{
+			var added = Program.AddSupportChannelId(channelOption.Id);
+			await SetResponseAsync(
+				context,
+				added
+					? $"Added <#{channelOption.Id}> (`{channelOption.Id}`) to the analyze channel allowlist."
+					: $"<#{channelOption.Id}> (`{channelOption.Id}`) is already in the analyze channel allowlist.");
+			return;
+		}
+
+		var removed = Program.RemoveSupportChannelId(channelOption.Id);
+		await SetResponseAsync(
+			context,
+			removed
+				? $"Removed <#{channelOption.Id}> (`{channelOption.Id}`) from the analyze channel allowlist."
+				: $"<#{channelOption.Id}> (`{channelOption.Id}`) was not in the analyze channel allowlist.");
+	}
+
+	private static string BuildChannelListMessage()
+	{
+		if (Program.SupportChannelIds.Count == 0)
+		{
+			return "Analyze is currently disabled. No channels are configured.";
+		}
+
+		var channelLines = Program.SupportChannelIds
+			.OrderBy(channelId => channelId)
+			.Select(channelId => $"- <#{channelId}> (`{channelId}`)");
+
+		return "Configured analyze channels:\n" + string.Join("\n", channelLines);
+	}
+
+	private static bool HasManageMessagesPermission(SocketSlashCommand context)
+	{
+		if (context.User is not SocketGuildUser guildUser)
+		{
+			return false;
+		}
+
+		if (context.Channel is IGuildChannel guildChannel)
+		{
+			return guildUser.GetPermissions(guildChannel).ManageMessages;
+		}
+
+		return guildUser.GuildPermissions.ManageMessages;
+	}
+
+	private static async Task<(IMessage Message, string ErrorMessage)> TryResolveTargetMessageAsync(DiscordSocketClient client, SocketSlashCommand context, string rawTarget)
+	{
+		if (!TryParseTarget(rawTarget, context.Channel.Id, out var channelId, out var messageId))
+		{
+			return (null, "That target must be a raw message ID in this channel or a full Discord message link.");
+		}
+
+		if (!Program.SupportChannelIds.Contains(channelId))
+		{
+			return (null, "The target message must be in a configured analyze channel.");
+		}
+
+		var channel = await TryGetMessageChannelAsync(client, channelId);
+		if (channel == null)
+		{
+			return (null, "I couldn't access that target channel.");
+		}
+
+		var message = await channel.GetMessageAsync(messageId);
+		if (message == null)
+		{
+			return (null, $"Couldn't find a message with ID `{messageId}` in <#{channelId}>.");
+		}
+
+		return (message, null);
+	}
+
+	private static async Task<IMessageChannel> TryGetMessageChannelAsync(DiscordSocketClient client, ulong channelId)
+	{
+		if (client.GetChannel(channelId) is IMessageChannel cachedMessageChannel)
+		{
+			return cachedMessageChannel;
+		}
+
+		var fetchedChannel = await client.GetChannelAsync(channelId);
+		return fetchedChannel as IMessageChannel;
+	}
+
+	private static bool TryParseTarget(string rawTarget, ulong currentChannelId, out ulong channelId, out ulong messageId)
+	{
+		if (ulong.TryParse(rawTarget, out messageId))
+		{
+			channelId = currentChannelId;
+			return true;
+		}
+
+		if (!Uri.TryCreate(rawTarget, UriKind.Absolute, out var uri))
+		{
+			channelId = 0;
+			messageId = 0;
+			return false;
+		}
+
+		if (!string.Equals(uri.Host, "discord.com", StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(uri.Host, "ptb.discord.com", StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(uri.Host, "canary.discord.com", StringComparison.OrdinalIgnoreCase))
+		{
+			channelId = 0;
+			messageId = 0;
+			return false;
+		}
+
+		var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+		if (segments.Length != 4 || !string.Equals(segments[0], "channels", StringComparison.OrdinalIgnoreCase))
+		{
+			channelId = 0;
+			messageId = 0;
+			return false;
+		}
+
+		return ulong.TryParse(segments[2], out channelId) && ulong.TryParse(segments[3], out messageId);
+	}
+
+	private static Task SetResponseAsync(SocketSlashCommand context, string message)
+	{
+		return context.ModifyOriginalResponseAsync(properties =>
+		{
+			properties.Content = message;
+			properties.Embed = null;
+			properties.Components = null;
+		});
+	}
+}

--- a/Events.cs
+++ b/Events.cs
@@ -139,11 +139,6 @@ internal static class Events
 			}
 		}
 
-		if (await Program.SupportLogAnalyzer.TryHandleMessageAsync(userMessage))
-		{
-			return;
-		}
-		
 		if (user.Roles.Any(role => Program.IgnoredRoleIds.ToList().Contains(role.Id)))
 		{
 			return;

--- a/Program.cs
+++ b/Program.cs
@@ -25,13 +25,14 @@ internal static class Program
 	public static bool BotActive = true;
 	public static DiscordSocketClient Client;
     public static string token = "";
+	private const ulong DefaultProductionSupportChannelId = 1354832385128271922;
 
     public static List<TriggerItem> TriggerItems = [];
 	internal static readonly List<Command> CommandsList = [];
 	internal static readonly List<ulong> WatchList = [];
 	internal static readonly HashSet<ulong> SupportChannelIds = [];
+	internal static readonly SupportLogSettingsStore SupportLogSettingsStore = new(DefaultProductionSupportChannelId);
 	internal static readonly SupportLogAnalyzer SupportLogAnalyzer = new();
-	private const ulong DefaultProductionSupportChannelId = 1354832385128271922;
 
 	// sorry repo, im not sure how to set this up for multiple testers
 	// you'll probably figure it out.
@@ -186,31 +187,38 @@ internal static class Program
 	private static void LoadSupportChannelIds()
 	{
 		SupportChannelIds.Clear();
-
-		var rawValue = Environment.GetEnvironmentVariable("SUPPORT_CHANNEL_IDS");
-		if (string.IsNullOrWhiteSpace(rawValue))
+		foreach (var channelId in SupportLogSettingsStore.LoadChannelIds())
 		{
-			SupportChannelIds.Add(DefaultProductionSupportChannelId);
-			Console.WriteLine($"Support log analysis enabled for the default production support channel ({DefaultProductionSupportChannelId}). Set SUPPORT_CHANNEL_IDS to override it.");
-			return;
-		}
-
-		foreach (var token in rawValue.Split([',', ';', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-		{
-			if (!ulong.TryParse(token, out var channelId))
-			{
-				Console.WriteLine($"Ignoring invalid support channel ID '{token}'.");
-				continue;
-			}
-
 			SupportChannelIds.Add(channelId);
 		}
 
 		Console.WriteLine(
 			SupportChannelIds.Count == 0
-				? "Support log analysis is disabled. SUPPORT_CHANNEL_IDS did not contain any valid IDs."
+				? "Support log analysis is disabled. No analyze channels are configured."
 				: $"Support log analysis enabled for {SupportChannelIds.Count} {Utils.Plural(SupportChannelIds.Count, "channel")}."
 		);
+	}
+
+	internal static bool AddSupportChannelId(ulong channelId)
+	{
+		var added = SupportChannelIds.Add(channelId);
+		if (added)
+		{
+			SupportLogSettingsStore.SaveChannelIds(SupportChannelIds);
+		}
+
+		return added;
+	}
+
+	internal static bool RemoveSupportChannelId(ulong channelId)
+	{
+		var removed = SupportChannelIds.Remove(channelId);
+		if (removed)
+		{
+			SupportLogSettingsStore.SaveChannelIds(SupportChannelIds);
+		}
+
+		return removed;
 	}
 	
 	#region Triggers and Command Loading
@@ -227,12 +235,6 @@ internal static class Program
     {
         // shouldnt error, but it may
         List<WarnItem> l;
-		ITextChannel c = null;
-#if PROD
-		c ??=  await Client.GetChannelAsync(1360653812829913128) as ITextChannel; // Main server
-#elif TEST
-        c ??= await Client.GetChannelAsync(1368263313531732011) as ITextChannel; // Test server id
-#endif
         try
         {
             l = JsonConvert.DeserializeObject<List<WarnItem>>(await File.ReadAllTextAsync("warns.json"));

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 Simple discord bot with auto responses to common phrases using modals, events, and string checking.
 
-Automatic log analysis defaults to the S1 Modding #support channel (`1354832385128271922`).
+## Support Log Analysis
 
-Set `SUPPORT_CHANNEL_IDS` to a comma-separated list of Discord channel IDs to override that default and control where automatic log analysis replies run for `.log`, `.txt`, or pasted error logs.
+- Log analysis is opt-in through `/analyze message target:<message-id-or-link>`.
+- The response is ephemeral, keeps the paginated embed flow, and is cleaned up after roughly 15 minutes.
+- `/analyze settings list`
+- `/analyze settings add-channel channel:<channel>`
+- `/analyze settings remove-channel channel:<channel>`
+- Settings are stored in `support-log-settings.json`.
+- On first run, if `support-log-settings.json` does not exist, it is seeded from `SUPPORT_CHANNEL_IDS`.
+- If `SUPPORT_CHANNEL_IDS` is not set on first run, the bot seeds the default production support channel (`1354832385128271922`).
 
 ## ErrorAnalyzer.Core dependency
 

--- a/SupportLogAnalyzer.cs
+++ b/SupportLogAnalyzer.cs
@@ -18,67 +18,32 @@ internal sealed class SupportLogAnalyzer
 
 	private static readonly HttpClient HttpClient = new();
 	private static readonly string[] SupportedAttachmentExtensions = [".log", ".txt"];
-	private static readonly ConcurrentDictionary<ulong, PaginationState> PaginationStates = new();
+	private static readonly ConcurrentDictionary<ulong, PaginationStates> Sessions = new();
 
 	private const int MaxAttachmentBytes = 10 * 1024 * 1024;
 	private const int IssueGroupsPerPage = 3;
 	private const int MaxEmbedFieldLength = 1024;
+	private static readonly TimeSpan AnalysisLifetime = TimeSpan.FromMinutes(14.5);
 
 	private readonly LogAnalyzer _analyzer = new();
 
-	internal async Task<bool> TryHandleMessageAsync(SocketUserMessage message)
+	internal async Task AnalyzeMessageAsync(SocketSlashCommand context, IMessage targetMessage)
 	{
-		if (!Program.SupportChannelIds.Contains(message.Channel.Id))
-		{
-			return false;
-		}
-
+		LogAnalysisResponse response;
 		try
 		{
-			var input = await TryExtractLogInputAsync(message.Attachments);
-			if (input == null)
-			{
-				return false;
-			}
-
-			if (!string.IsNullOrWhiteSpace(input.ErrorMessage))
-			{
-				await SendReplyAsync(message, BuildStatusEmbed(input.SourceName, input.ErrorMessage, Color.Orange));
-				return true;
-			}
-
-			if (!ContainsException(input.Text))
-			{
-				return false;
-			}
-
-			var pageSet = BuildPages(input);
-			if (pageSet == null)
-			{
-				return false;
-			}
-
-			var sentMessage = await message.Channel.SendMessageAsync(
-				embed: pageSet.Embeds[0],
-				components: BuildPaginationComponents(0, pageSet.Embeds.Count),
-				messageReference: new MessageReference(message.Id),
-				allowedMentions: AllowedMentions.None);
-
-			if (pageSet.Embeds.Count > 1)
-			{
-				PaginationStates[sentMessage.Id] = new PaginationState(pageSet.Embeds);
-			}
-
-			return true;
+			response = await BuildResponseAsync(targetMessage);
 		}
 		catch (Exception ex)
 		{
 			Console.WriteLine($"Support log analysis failed: {ex}");
-			await SendReplyAsync(
-				message,
-				BuildStatusEmbed("discord-log", "I hit an error while analyzing that log. Please try again or let a helper review it manually.", Color.Orange));
-			return true;
+			response = LogAnalysisResponse.FromStatus(BuildStatusEmbed(
+				$"message {targetMessage.Id}",
+				"I hit an error while analyzing that log. Please try again or let a helper review it manually.",
+				Color.Orange));
 		}
+
+		await SendResponseAsync(context, response);
 	}
 
 	internal async Task<bool> TryHandlePaginationAsync(SocketMessageComponent component)
@@ -99,22 +64,16 @@ internal sealed class SupportLogAnalyzer
 			return true;
 		}
 
-		if (!PaginationStates.TryGetValue(component.Message.Id, out var state))
+		if (!Sessions.TryGetValue(component.Message.Id, out var state) || state.ExpiresAt <= DateTimeOffset.UtcNow)
 		{
-			try
-			{
-				await component.ModifyOriginalResponseAsync(message =>
-				{
-					message.Content = "That log analysis is no longer interactive.";
-					message.Embeds = null;
-					message.Components = null;
-				});
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"Failed to remove stale pagination state for message {component.Message?.Id}: {ex.Message}");
-			}
+			Sessions.TryRemove(component.Message.Id, out _);
+			await TryShowExpiredResponseAsync(component);
+			return true;
+		}
 
+		if (component.User.Id != state.OwnerUserId)
+		{
+			await component.FollowupAsync("Only the user who ran this analysis can change pages.", ephemeral: true);
 			return true;
 		}
 
@@ -135,6 +94,7 @@ internal sealed class SupportLogAnalyzer
 		{
 			await component.ModifyOriginalResponseAsync(properties =>
 			{
+				properties.Content = null;
 				properties.Embed = state.Embeds[state.CurrentPage];
 				properties.Components = BuildPaginationComponents(state.CurrentPage, state.Embeds.Count);
 			});
@@ -147,9 +107,45 @@ internal sealed class SupportLogAnalyzer
 		return true;
 	}
 
-	private async Task<LogInput> TryExtractLogInputAsync(IReadOnlyCollection<Attachment> attachments)
+	private async Task<LogAnalysisResponse> BuildResponseAsync(IMessage message)
 	{
-		foreach (var attachment in attachments)
+		var input = await TryExtractLogInputAsync(message);
+		if (input == null)
+		{
+			return LogAnalysisResponse.FromStatus(BuildStatusEmbed(
+				$"message {message.Id}",
+				"I couldn't find a supported `.log` or `.txt` attachment on that message.",
+				Color.Orange));
+		}
+
+		if (!string.IsNullOrWhiteSpace(input.ErrorMessage))
+		{
+			return LogAnalysisResponse.FromStatus(BuildStatusEmbed(input.SourceName, input.ErrorMessage, Color.Orange));
+		}
+
+		if (!ContainsException(input.Text))
+		{
+			return LogAnalysisResponse.FromStatus(BuildStatusEmbed(
+				input.SourceName,
+				"I couldn't find an exception in that log, so there isn't anything to analyze automatically.",
+				Color.Orange));
+		}
+
+		var pageSet = BuildPages(input);
+		if (pageSet == null)
+		{
+			return LogAnalysisResponse.FromStatus(BuildStatusEmbed(
+				input.SourceName,
+				"I couldn't identify any actionable issue groups in that log.",
+				Color.Blue));
+		}
+
+		return new LogAnalysisResponse(pageSet.Embeds);
+	}
+
+	private async Task<LogInput> TryExtractLogInputAsync(IMessage message)
+	{
+		foreach (var attachment in message.Attachments)
 		{
 			if (!HasSupportedExtension(attachment.Filename))
 			{
@@ -169,6 +165,68 @@ internal sealed class SupportLogAnalyzer
 		}
 
 		return null;
+	}
+
+	private async Task SendResponseAsync(SocketSlashCommand context, LogAnalysisResponse response)
+	{
+		await context.ModifyOriginalResponseAsync(properties =>
+		{
+			properties.Content = null;
+			properties.Embed = response.Embeds[0];
+			properties.Components = BuildPaginationComponents(0, response.Embeds.Count);
+		});
+
+		var responseMessage = await context.GetOriginalResponseAsync();
+		var expiresAt = DateTimeOffset.UtcNow.Add(AnalysisLifetime);
+		if (response.Embeds.Count > 1)
+		{
+			Sessions[responseMessage.Id] = new PaginationStates(response.Embeds, context.User.Id, expiresAt);
+		}
+
+		ScheduleResponseCleanup(context, responseMessage.Id, expiresAt);
+	}
+
+	private void ScheduleResponseCleanup(SocketSlashCommand context, ulong responseMessageId, DateTimeOffset expiresAt)
+	{
+		Program.RunBackgroundTask(nameof(ScheduleResponseCleanup), async () =>
+		{
+			var delay = expiresAt - DateTimeOffset.UtcNow;
+			if (delay > TimeSpan.Zero)
+			{
+				await Task.Delay(delay);
+			}
+
+			Sessions.TryRemove(responseMessageId, out _);
+
+			try
+			{
+				await context.DeleteOriginalResponseAsync();
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[SupportLogAnalyzer] Failed to delete expired analysis response {responseMessageId}: {ex.Message}");
+			}
+		});
+	}
+
+	private static async Task TryShowExpiredResponseAsync(SocketMessageComponent component)
+	{
+		try
+		{
+			await component.ModifyOriginalResponseAsync(properties =>
+			{
+				properties.Content = null;
+				properties.Embed = BuildStatusEmbed(
+					"discord-log",
+					"This log analysis expired. Run `/analyze message` again if you still need it.",
+					Color.DarkGrey);
+				properties.Components = null;
+			});
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[SupportLogAnalyzer] Failed to show expired state for message {component.Message?.Id}: {ex.Message}");
+		}
 	}
 
 	private PageSet BuildPages(LogInput input)
@@ -354,14 +412,6 @@ internal sealed class SupportLogAnalyzer
 			.Build();
 	}
 
-	private static async Task SendReplyAsync(SocketUserMessage message, Embed embed)
-	{
-		await message.Channel.SendMessageAsync(
-			embed: embed,
-			messageReference: new MessageReference(message.Id),
-			allowedMentions: AllowedMentions.None);
-	}
-
 	private static Embed BuildStatusEmbed(string sourceName, string message, Color color)
 	{
 		return new EmbedBuilder()
@@ -430,16 +480,28 @@ internal sealed class SupportLogAnalyzer
 
 	private sealed record AdviceGroupPageItem(DiagnosisAdviceGroupDto Group, IReadOnlyList<DiagnosisDto> Diagnoses);
 
-	private sealed class PaginationState
+	private sealed class PaginationStates
 	{
-		internal PaginationState(IReadOnlyList<Embed> embeds)
+		internal PaginationStates(IReadOnlyList<Embed> embeds, ulong ownerUserId, DateTimeOffset expiresAt)
 		{
 			Embeds = embeds;
+			OwnerUserId = ownerUserId;
+			ExpiresAt = expiresAt;
 		}
 
 		internal object SyncRoot { get; } = new();
 		internal IReadOnlyList<Embed> Embeds { get; }
+		internal ulong OwnerUserId { get; }
+		internal DateTimeOffset ExpiresAt { get; }
 		internal int CurrentPage { get; set; }
+	}
+
+	private sealed record LogAnalysisResponse(IReadOnlyList<Embed> Embeds)
+	{
+		internal static LogAnalysisResponse FromStatus(Embed embed)
+		{
+			return new LogAnalysisResponse([embed]);
+		}
 	}
 
 	private sealed record PageSet(IReadOnlyList<Embed> Embeds);

--- a/SupportLogSettingsStore.cs
+++ b/SupportLogSettingsStore.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace NelsonsWeirdTwin;
+
+internal sealed class SupportLogSettingsStore
+{
+	private const string SettingsFilePath = "support-log-settings.json";
+
+	private readonly ulong _defaultProductionSupportChannelId;
+
+	internal SupportLogSettingsStore(ulong defaultProductionSupportChannelId)
+	{
+		_defaultProductionSupportChannelId = defaultProductionSupportChannelId;
+	}
+
+	internal HashSet<ulong> LoadChannelIds()
+	{
+		var settings = LoadSettings();
+		return settings.ChannelIds
+			.Where(channelId => channelId != 0)
+			.ToHashSet();
+	}
+
+	internal void SaveChannelIds(IEnumerable<ulong> channelIds)
+	{
+		var distinctChannelIds = channelIds
+			.Where(channelId => channelId != 0)
+			.Distinct()
+			.OrderBy(channelId => channelId)
+			.ToList();
+
+		var settings = new SupportLogSettings
+		{
+			ChannelIds = distinctChannelIds
+		};
+		File.WriteAllText(SettingsFilePath, JsonConvert.SerializeObject(settings, Formatting.Indented));
+	}
+
+	private SupportLogSettings LoadSettings()
+	{
+		if (File.Exists(SettingsFilePath))
+		{
+			try
+			{
+				var rawSettings = File.ReadAllText(SettingsFilePath);
+				var settings = JsonConvert.DeserializeObject<SupportLogSettings>(rawSettings);
+				if (settings?.ChannelIds != null)
+				{
+					Console.WriteLine($"Loaded support log settings from {SettingsFilePath}.");
+					return settings;
+				}
+
+				Console.WriteLine($"{SettingsFilePath} did not contain any usable settings. Re-seeding from environment/defaults.");
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"Failed to load {SettingsFilePath}: {ex.Message}. Re-seeding from environment/defaults.");
+			}
+		}
+
+		var seededChannelIds = ParseChannelIdsFromEnvironment();
+		if (seededChannelIds.Count == 0)
+		{
+			seededChannelIds.Add(_defaultProductionSupportChannelId);
+			Console.WriteLine($"Support log settings were seeded with the default production support channel ({_defaultProductionSupportChannelId}).");
+		}
+		else
+		{
+			Console.WriteLine($"Support log settings were seeded from SUPPORT_CHANNEL_IDS into {SettingsFilePath}.");
+		}
+
+		SaveChannelIds(seededChannelIds);
+		return new SupportLogSettings
+		{
+			ChannelIds = seededChannelIds.OrderBy(channelId => channelId).ToList()
+		};
+	}
+
+	private static List<ulong> ParseChannelIdsFromEnvironment()
+	{
+		var channelIds = new List<ulong>();
+		var rawValue = Environment.GetEnvironmentVariable("SUPPORT_CHANNEL_IDS");
+		if (string.IsNullOrWhiteSpace(rawValue))
+		{
+			return channelIds;
+		}
+
+		foreach (var token in rawValue.Split([',', ';', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (!ulong.TryParse(token, out var channelId))
+			{
+				Console.WriteLine($"Ignoring invalid support channel ID '{token}'.");
+				continue;
+			}
+
+			channelIds.Add(channelId);
+		}
+
+		return channelIds;
+	}
+
+	private sealed class SupportLogSettings
+	{
+		[JsonProperty("channelIds")]
+		public List<ulong> ChannelIds { get; init; } = [];
+	}
+}


### PR DESCRIPTION
## Summary

This PR moves support log analysis from an automatic message listener to an explicit slash command flow and adds persistent channel configuration for where analysis is allowed.

The old automatic flow could trigger analysis directly from channel traffic. This change makes analysis intentional, keeps results private to the requester, and gives moderators a way to manage allowed channels without redeploying or changing environment variables.


## Changes

- Added `/analyze message target:<message-id-or-link>` to analyze a message with a `.log` or `.txt` attachment
- Added `/analyze settings` subcommands to manage the allowlist of channels:
  - `list`
  - `add-channel`
  - `remove-channel`
- Persisted analyze channel settings in `support-log-settings.json`
- Seeded settings on first run from `SUPPORT_CHANNEL_IDS` or from the default production support channel if that env var is not set
- Removed automatic support-log analysis from normal message handling
- Updated analyzer responses to work as ephemeral slash-command responses instead of public reply messages
- Kept paginated analysis embeds, but restricted pagination to the user who ran the command
- Added expiration/cleanup for analysis sessions after about 15 minutes

## Permissions

- `/analyze message` can be used by members in configured analyze channels.
- `/analyze settings list|add-channel|remove-channel` requires ManageMessages.
- Only the user who started an analysis can change its pages.
- Analysis responses are ephemeral and expire after roughly 15 minutes.