### PR TITLE
fix(bot): bump ErrorAnalyzer.Core to 0.1.2 for fixing support-log false positives

### DIFF
--- a/NelsonsWeirdTwin.csproj
+++ b/NelsonsWeirdTwin.csproj
@@ -7,7 +7,7 @@
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<Configurations>ProdBot;TestBot</Configurations>
 	<UseLocalErrorAnalyzerCore Condition="'$(UseLocalErrorAnalyzerCore)' == ''">false</UseLocalErrorAnalyzerCore>
-	<ErrorAnalyzerCoreVersion Condition="'$(ErrorAnalyzerCoreVersion)' == ''">*</ErrorAnalyzerCoreVersion>
+	<ErrorAnalyzerCoreVersion Condition="'$(ErrorAnalyzerCoreVersion)' == ''">0.1.2</ErrorAnalyzerCoreVersion>
 	<ErrorAnalyzerCoreProjectPath Condition="'$(ErrorAnalyzerCoreProjectPath)' == ''">..\ErrorAnalyzer\src\ErrorAnalyzer.Core\ErrorAnalyzer.Core.csproj</ErrorAnalyzerCoreProjectPath>
   </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)' == 'ProdBot'">


### PR DESCRIPTION
## Summary

This fixes several false positives in support log analysis that were showing up in the Discord support channel.

Harmony reflection scan noise was being treated like real outdated mod failures, which caused entries such as `MLVScan`, `Il2Cppmscorlib`, and multiple `UnityEngine.*` assemblies to appear in affected mods even though they were not the real issue.

This change:
- filters Harmony `AccessTools.GetTypesFromAssembly` loader noise for framework/internal assemblies
- avoids treating framework assembly names as mod names during ownership resolution
- adds a regression test using the support-channel log that showed the bad output

## Testing

- `dotnet test ErrorAnalyzer.sln -nologo`

## Notes

The false positives were found from the support-channel `/analyze message` output shown in Discord, where framework assemblies and unrelated names were being listed as affected mods.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/79a2605c-e47f-4fdd-9b79-1c19a4130c11" />
